### PR TITLE
windows: fix transferToBase64 thread affinity

### DIFF
--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -106,7 +106,7 @@ class SketchCanvas extends React.Component {
   clear() {
     this._paths = []
     this._path = null
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.clear, [])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.clear, [])
   }
 
   undo() {
@@ -123,7 +123,7 @@ class SketchCanvas extends React.Component {
         const coor = p.split(',').map(pp => parseFloat(pp).toFixed(2))
         return `${coor[0] * this._screenScale * this._size.width / data.size.width},${coor[1] * this._screenScale * this._size.height / data.size.height}`;
       })
-      UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPath, [
+      UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.addPath, [
         data.path.id, processColor(data.path.color), data.path.width * this._screenScale, pathData
       ])
     } else {
@@ -133,11 +133,11 @@ class SketchCanvas extends React.Component {
 
   deletePath(id) {
     this._paths = this._paths.filter(p => p.path.id !== id)
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.deletePath, [id])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.deletePath, [id])
   }
 
   save(imageType, transparent, folder, filename, includeImage, includeText, cropToImageSize) {
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
   }
 
   getPaths() {
@@ -171,7 +171,7 @@ class SketchCanvas extends React.Component {
         
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.newPath,
+          UIManager.getViewManagerConfig('RNSketchCanvas').Commands.newPath,
           [
             this._path.id,
             processColor(this._path.color),
@@ -180,7 +180,7 @@ class SketchCanvas extends React.Component {
         )
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.addPoint,
+          UIManager.getViewManagerConfig('RNSketchCanvas').Commands.addPoint,
           [
             parseFloat((gestureState.x0 - this._offset.x).toFixed(2) * this._screenScale),
             parseFloat((gestureState.y0 - this._offset.y).toFixed(2) * this._screenScale)
@@ -193,7 +193,7 @@ class SketchCanvas extends React.Component {
       onPanResponderMove: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
         if (this._path) {
-          UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPoint, [
+          UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.addPoint, [
             parseFloat((gestureState.moveX - this._offset.x).toFixed(2) * this._screenScale),
             parseFloat((gestureState.moveY - this._offset.y).toFixed(2) * this._screenScale)
           ])
@@ -208,7 +208,7 @@ class SketchCanvas extends React.Component {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })
         }
-        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig('RNSketchCanvas').Commands.endPath, [])
       },
 
       onShouldBlockNativeResponder: (evt, gestureState) => {
@@ -255,12 +255,12 @@ class SketchCanvas extends React.Component {
   }
 }
 
-SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' || Platform.OS === 'windows' ? UIManager.RNSketchCanvas.Constants.MainBundlePath : '';
-SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSDocumentDirectory : '';
-SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSLibraryDirectory : '';
-SketchCanvas.CACHES = Platform.OS === 'ios' ||  Platform.OS === 'windows' ? UIManager.RNSketchCanvas.Constants.NSCachesDirectory : '';
-SketchCanvas.TEMPORARY = Platform.OS === 'windows' ? UIManager.RNSketchCanvas.Constants.TemporaryDirectory : '';
-SketchCanvas.ROAMING = Platform.OS === 'windows' ? UIManager.RNSketchCanvas.Constants.RoamingDirectory : '';
-SketchCanvas.LOCAL = Platform.OS === 'windows' ? UIManager.RNSketchCanvas.Constants.LocalDirectory : '';
+SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' || Platform.OS === 'windows' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.MainBundlePath : '';
+SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.NSDocumentDirectory : '';
+SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.NSLibraryDirectory : '';
+SketchCanvas.CACHES = Platform.OS === 'ios' ||  Platform.OS === 'windows' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.NSCachesDirectory : '';
+SketchCanvas.TEMPORARY = Platform.OS === 'windows' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.TemporaryDirectory : '';
+SketchCanvas.ROAMING = Platform.OS === 'windows' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.RoamingDirectory : '';
+SketchCanvas.LOCAL = Platform.OS === 'windows' ? UIManager.getViewManagerConfig('RNSketchCanvas').Constants.LocalDirectory : '';
 
 module.exports = SketchCanvas;

--- a/windows/RNSketchCanvas/RNSketchCanvasModule.h
+++ b/windows/RNSketchCanvas/RNSketchCanvasModule.h
@@ -38,7 +38,7 @@ namespace winrt::RNSketchCanvas
       {
         XamlUIService uiService = XamlUIService::FromContext(reactContext.Handle());
         auto sketchCanvasInstance = uiService.ElementFromReactTag(tag).as<winrt::RNSketchCanvas::implementation::RNSketchCanvasView>();
-        IAsyncOperation<winrt::hstring> asyncOp = sketchCanvasInstance.get()->getBase64(type, transparent, includeImage, includeText, cropToImageSize);
+        IAsyncOperation<winrt::hstring> asyncOp = sketchCanvasInstance->getBase64(type, transparent, includeImage, includeText, cropToImageSize);
         asyncOp.Completed([=](IAsyncOperation<winrt::hstring> const& sender, AsyncStatus const asyncStatus)
           {
             if (asyncStatus == AsyncStatus::Error)


### PR DESCRIPTION
Fixes transferToBase64 thread affinity for compatibility with react-native-windows >= 0.64.