### PR TITLE
[Windows] Changed directory to save to from PicturesLibary to TemporaryDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ RNSketchCanvas supports autolinking. Just call: `npm i @terrylinla/react-native-
 8. In `App.cpp` add `PackageProviders().Append(winrt::RNSketchCanvas::ReactPackageProvider());` before `InitializeComponent();`
 
 #### Using save on Windows
-On Windows, `save()` will save the resulting image in the Pictures library. In order for the application to save successfully, the `Pictures Library` capability must be added to the application's manifest:
-1. Open your solution in Visual Studio 2019 (eg. `windows\yourapp.sln`)
-2. In the main application project, open the `Package.appxmanifest` file.
-3. In the `Capabilities` tab, check the `Pictures Library` capability.
+On Windows, `save()` will save the resulting image in the TemporaryDirectory folder of the application.
 
 ## Usage
 -------------
@@ -101,45 +98,45 @@ AppRegistry.registerComponent('example', () => example);
 
 #### Properties
 -------------
-| Prop  | Type | Description |
-| :------------ |:---------------:| :---------------| 
-| style | `object` | Styles to be applied on canvas component |
-| strokeColor | `string` | Set the color of stroke, which can be #RRGGBB or #RRGGBBAA. If strokeColor is set to #00000000, it will automatically become an eraser. <br/>NOTE: Once an eraser path is sent to Android, Android View will disable hardware acceleration automatically. It might reduce the canvas performance afterward. |
-| strokeWidth | `number` | The thickness of stroke |
-| onStrokeStart | `function` | An optional function which accepts 2 arguments `x` and `y`. Called when user's finger touches the canvas (starts to draw) |
-| onStrokeChanged | `function` | An optional function which accepts 2 arguments `x` and `y`. Called when user's finger moves |
-| onStrokeEnd | `function` | An optional function called when user's finger leaves the canvas (end drawing) |
-| onSketchSaved | `function` | An optional function which accepts 2 arguments `success` and `path`. If `success` is true, image is saved successfully and the saved image path might be in second argument. In Android, image path will always be returned. In iOS, image is saved to camera roll or file system, path will be set to null or image location respectively. In Windows, image is saved to the Pictures library. |
-| onPathsChange | `function` | An optional function which accepts 1 argument `pathsCount`, which indicates the number of paths. Useful for UI controls. (Thanks to toblerpwn) |
-| user | `string` | An identifier to identify who draws the path. Useful when undo between two users |
-| touchEnabled | `bool` | If false, disable touching. Default is true.  |
-| localSourceImage | `object` | Require an object (see [below](#objects)) which consists of `filename`, `directory`(optional) and `mode`(optional). If set, the image will be loaded and display as a background in canvas. (Thanks to diego-caceres-galvan))([Here](#background-image) for details) |
-| permissionDialogTitle | `string` | Android Only: Provide a Dialog Title for the Image Saving PermissionDialog. Defaults to empty string if not set |
-| permissionDialogMessage | `string` | Android Only: Provide a Dialog Message for the Image Saving PermissionDialog. Defaults to empty string if not set |
+| Prop                    |    Type    | Description                                                                                                                                                                                                                                                                                                                                                                                     |
+| :---------------------- | :--------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| style                   |  `object`  | Styles to be applied on canvas component                                                                                                                                                                                                                                                                                                                                                        |
+| strokeColor             |  `string`  | Set the color of stroke, which can be #RRGGBB or #RRGGBBAA. If strokeColor is set to #00000000, it will automatically become an eraser. <br/>NOTE: Once an eraser path is sent to Android, Android View will disable hardware acceleration automatically. It might reduce the canvas performance afterward.                                                                                     |
+| strokeWidth             |  `number`  | The thickness of stroke                                                                                                                                                                                                                                                                                                                                                                         |
+| onStrokeStart           | `function` | An optional function which accepts 2 arguments `x` and `y`. Called when user's finger touches the canvas (starts to draw)                                                                                                                                                                                                                                                                       |
+| onStrokeChanged         | `function` | An optional function which accepts 2 arguments `x` and `y`. Called when user's finger moves                                                                                                                                                                                                                                                                                                     |
+| onStrokeEnd             | `function` | An optional function called when user's finger leaves the canvas (end drawing)                                                                                                                                                                                                                                                                                                                  |
+| onSketchSaved           | `function` | An optional function which accepts 2 arguments `success` and `path`. If `success` is true, image is saved successfully and the saved image path might be in second argument. In Android, image path will always be returned. In iOS, image is saved to camera roll or file system, path will be set to null or image location respectively. In Windows, image is saved to the Pictures library. |
+| onPathsChange           | `function` | An optional function which accepts 1 argument `pathsCount`, which indicates the number of paths. Useful for UI controls. (Thanks to toblerpwn)                                                                                                                                                                                                                                                  |
+| user                    |  `string`  | An identifier to identify who draws the path. Useful when undo between two users                                                                                                                                                                                                                                                                                                                |
+| touchEnabled            |   `bool`   | If false, disable touching. Default is true.                                                                                                                                                                                                                                                                                                                                                    |
+| localSourceImage        |  `object`  | Require an object (see [below](#objects)) which consists of `filename`, `directory`(optional) and `mode`(optional). If set, the image will be loaded and display as a background in canvas. (Thanks to diego-caceres-galvan))([Here](#background-image) for details)                                                                                                                            |
+| permissionDialogTitle   |  `string`  | Android Only: Provide a Dialog Title for the Image Saving PermissionDialog. Defaults to empty string if not set                                                                                                                                                                                                                                                                                 |
+| permissionDialogMessage |  `string`  | Android Only: Provide a Dialog Message for the Image Saving PermissionDialog. Defaults to empty string if not set                                                                                                                                                                                                                                                                               |
 
 #### Methods
 -------------
-| Method | Description |
-| :------------ |:---------------|
-| clear() | Clear all the paths |
-| undo() | Delete the latest path. Can undo multiple times. |
-| addPath(path) | Add a path (see [below](#objects)) to canvas.  |
-| deletePath(id) | Delete a path with its `id` |
+| Method                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :---------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clear()                                                                       | Clear all the paths                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| undo()                                                                        | Delete the latest path. Can undo multiple times.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| addPath(path)                                                                 | Add a path (see [below](#objects)) to canvas.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| deletePath(id)                                                                | Delete a path with its `id`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | save(imageType, transparent, folder, filename, includeImage, cropToImageSize) | Save image to camera roll or filesystem. If `localSourceImage` is set and a background image is loaded successfully, set `includeImage` to true to include background image and set `cropToImageSize` to true to crop output image to background image.<br/>Android: Save image in `imageType` format with transparent background (if `transparent` sets to True) to **/sdcard/Pictures/`folder`/`filename`** (which is Environment.DIRECTORY_PICTURES).<br/>iOS: Save image in `imageType` format with transparent background (if `transparent` sets to True) to camera roll or file system. If `folder` and `filename` are set, image will save to **temporary directory/`folder`/`filename`** (which is NSTemporaryDirectory())<br/>Windows: Save image in `imageType` format with transparent background (if `transparent` sets to True) to the Pictures library. |
-| getPaths() | Get the paths that drawn on the canvas |
-| getBase64(imageType, transparent, includeImage, cropToImageSize, callback) | Get the base64 of image and receive data in callback function, which called with 2 arguments. First one is error (null if no error) and second one is base64 result. |
+| getPaths()                                                                    | Get the paths that drawn on the canvas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| getBase64(imageType, transparent, includeImage, cropToImageSize, callback)    | Get the base64 of image and receive data in callback function, which called with 2 arguments. First one is error (null if no error) and second one is base64 result.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 #### Constants
 -------------
-| Constant | Description |
-| :------------ |:---------------|
-| MAIN_BUNDLE | Android: empty string, '' <br/>iOS: equivalent to [[NSBundle mainBundle] bundlePath] <br/> Windows : `ms-appx://` |
-| DOCUMENT | Android: empty string, '' <br/>iOS: equivalent to NSDocumentDirectory <br/> Windows: empty string, '' |
-| LIBRARY | Android: empty string, '' <br/>iOS: equivalent to NSLibraryDirectory <br/> Windows: empty string, '' |
-| CACHES | Android: empty string, '' <br/>iOS: equivalent to NSCachesDirectory <br/> Windows: equivalent to `ApplicationData::Current().LocalCacheFolder().Path());`|
-| TEMPORARY | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///temp` |
-| ROAMING | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///roaming` |
-| LOCAL | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///local` |
+| Constant    | Description                                                                                                                                               |
+| :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MAIN_BUNDLE | Android: empty string, '' <br/>iOS: equivalent to [[NSBundle mainBundle] bundlePath] <br/> Windows : `ms-appx://`                                         |
+| DOCUMENT    | Android: empty string, '' <br/>iOS: equivalent to NSDocumentDirectory <br/> Windows: empty string, ''                                                     |
+| LIBRARY     | Android: empty string, '' <br/>iOS: equivalent to NSLibraryDirectory <br/> Windows: empty string, ''                                                      |
+| CACHES      | Android: empty string, '' <br/>iOS: equivalent to NSCachesDirectory <br/> Windows: equivalent to `ApplicationData::Current().LocalCacheFolder().Path());` |
+| TEMPORARY   | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///temp`                                                                    |
+| ROAMING     | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///roaming`                                                                 |
+| LOCAL       | Android: empty string, '' <br/>iOS: empty string, '' <br/> Windows : `ms-appx:///local`                                                                   |
 
 ### ● Using with build-in UI components
 <img src="https://i.imgur.com/O0vVdD6.png" height="400" />
@@ -224,56 +221,56 @@ AppRegistry.registerComponent('example', () => example);
 
 #### Properties
 -------------
-| Prop  | Type | Description |
-| :------------ |:---------------:| :---------------| 
-| containerStyle | `object` | Styles to be applied on container |
-| canvasStyle | `object` | Styles to be applied on canvas component |
-| onStrokeStart | `function` | See [above](#properties) |
-| onStrokeChanged | `function` | See [above](#properties) |
-| onStrokeEnd | `function` | See [above](#properties) |
-| onPathsChange | `function` | See [above](#properties) |
-| onClosePressed | `function` | An optional function called when user taps closeComponent |
-| onUndoPressed | `function` | An optional function that accepts a argument `id` (the deleted id of path) and is called when user taps "undo" |
-| onClearPressed | `function` | An optional function called when user taps clearComponent |
-| user | `string` | See [above](#properties) |
-| closeComponent | `component` | An optional component for closing |
-| eraseComponent | `component` | An optional component for eraser |
-| undoComponent | `component` | An optional component for undoing |
-| clearComponent | `component` | An optional component for clearing |
-| saveComponent | `component` | An optional component for saving |
-| strokeComponent | `function` | An optional function which accpets 1 argument `color` and should return a component. |
-| strokeSelectedComponent | `function` | An optional function which accpets 3 arguments `color`, `selectedIndex`, `isColorChanged` and should return a component. `isColorChanged` is useful for animating when changing color. Because rerendering also calls this function, we need `isColorChanged` to determine whether the component is rerendering or the selected color is changed. |
-| strokeWidthComponent | `function` | An optional function which accpets 1 argument `width` and should return a component. |
-| strokeColors | `array` | An array of colors. Example: `[{ color: '#000000' }, {color: '#FF0000'}]` |
-| defaultStrokeIndex | `numbber` | The default index of selected stroke color |
-| defaultStrokeWidth | `number` | The default thickness of stroke |
-| minStrokeWidth | `number` | The minimum value of thickness |
-| maxStrokeWidth | `number` | The maximum value of thickness |
-| strokeWidthStep | `number` | The step value of thickness when tapping `strokeWidthComponent`. |
-| savePreference | `function` | A function which is called when saving image and should return an object (see [below](#objects)). |
-| onSketchSaved | `function` | See [above](#properties) |
+| Prop                    |    Type     | Description                                                                                                                                                                                                                                                                                                                                       |
+| :---------------------- | :---------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| containerStyle          |  `object`   | Styles to be applied on container                                                                                                                                                                                                                                                                                                                 |
+| canvasStyle             |  `object`   | Styles to be applied on canvas component                                                                                                                                                                                                                                                                                                          |
+| onStrokeStart           | `function`  | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
+| onStrokeChanged         | `function`  | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
+| onStrokeEnd             | `function`  | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
+| onPathsChange           | `function`  | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
+| onClosePressed          | `function`  | An optional function called when user taps closeComponent                                                                                                                                                                                                                                                                                         |
+| onUndoPressed           | `function`  | An optional function that accepts a argument `id` (the deleted id of path) and is called when user taps "undo"                                                                                                                                                                                                                                    |
+| onClearPressed          | `function`  | An optional function called when user taps clearComponent                                                                                                                                                                                                                                                                                         |
+| user                    |  `string`   | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
+| closeComponent          | `component` | An optional component for closing                                                                                                                                                                                                                                                                                                                 |
+| eraseComponent          | `component` | An optional component for eraser                                                                                                                                                                                                                                                                                                                  |
+| undoComponent           | `component` | An optional component for undoing                                                                                                                                                                                                                                                                                                                 |
+| clearComponent          | `component` | An optional component for clearing                                                                                                                                                                                                                                                                                                                |
+| saveComponent           | `component` | An optional component for saving                                                                                                                                                                                                                                                                                                                  |
+| strokeComponent         | `function`  | An optional function which accpets 1 argument `color` and should return a component.                                                                                                                                                                                                                                                              |
+| strokeSelectedComponent | `function`  | An optional function which accpets 3 arguments `color`, `selectedIndex`, `isColorChanged` and should return a component. `isColorChanged` is useful for animating when changing color. Because rerendering also calls this function, we need `isColorChanged` to determine whether the component is rerendering or the selected color is changed. |
+| strokeWidthComponent    | `function`  | An optional function which accpets 1 argument `width` and should return a component.                                                                                                                                                                                                                                                              |
+| strokeColors            |   `array`   | An array of colors. Example: `[{ color: '#000000' }, {color: '#FF0000'}]`                                                                                                                                                                                                                                                                         |
+| defaultStrokeIndex      |  `numbber`  | The default index of selected stroke color                                                                                                                                                                                                                                                                                                        |
+| defaultStrokeWidth      |  `number`   | The default thickness of stroke                                                                                                                                                                                                                                                                                                                   |
+| minStrokeWidth          |  `number`   | The minimum value of thickness                                                                                                                                                                                                                                                                                                                    |
+| maxStrokeWidth          |  `number`   | The maximum value of thickness                                                                                                                                                                                                                                                                                                                    |
+| strokeWidthStep         |  `number`   | The step value of thickness when tapping `strokeWidthComponent`.                                                                                                                                                                                                                                                                                  |
+| savePreference          | `function`  | A function which is called when saving image and should return an object (see [below](#objects)).                                                                                                                                                                                                                                                 |
+| onSketchSaved           | `function`  | See [above](#properties)                                                                                                                                                                                                                                                                                                                          |
 
 #### Methods
 -------------
-| Method | Description |
-| :------------ |:---------------|
-| clear() | See [above](#methods) |
-| undo() | See [above](#methods) |
-| addPath(path) | See [above](#methods) |
+| Method         | Description           |
+| :------------- | :-------------------- |
+| clear()        | See [above](#methods) |
+| undo()         | See [above](#methods) |
+| addPath(path)  | See [above](#methods) |
 | deletePath(id) | See [above](#methods) |
-| save() |  |
+| save()         |                       |
 
 #### Constants
 -------------
-| Constant | Description |
-| :------------ |:---------------|
+| Constant    | Description             |
+| :---------- | :---------------------- |
 | MAIN_BUNDLE | See [above](#constants) |
-| DOCUMENT | See [above](#constants) |
-| LIBRARY | See [above](#constants) |
-| CACHES | See [above](#constants) |
-| TEMPORARY | See [above](#constants) |
-| ROAMING | See [above](#constants) |
-| LOCAL | See [above](#constants) |
+| DOCUMENT    | See [above](#constants) |
+| LIBRARY     | See [above](#constants) |
+| CACHES      | See [above](#constants) |
+| TEMPORARY   | See [above](#constants) |
+| ROAMING     | See [above](#constants) |
+| LOCAL       | See [above](#constants) |
 
 ## Background Image
 -------------
@@ -323,15 +320,15 @@ Note: Because native module cannot read the file in JS bundle, file path cannot 
   cropToImageSize: true
 }
 ```
-| Property | Type | Description |
-| :------------ |:---------------|:---------------|
-| folder? | string | Android: the folder name in `Pictures` directory<br/>iOS: if `filename` is not null, image will save to temporary directory with folder and filename, otherwise, it will save to camera roll<br/>Windows: the folder name in the Pictures Library |
-| filename? | string | the file name of image<br/>iOS: Set to `null` to save image to camera roll. |
-| transparent | boolean | save canvas with transparent background, ignored if imageType is `jpg` |
-| imageType | string  | image file format<br/>Options: `png`, `jpg` |
-| includeImage? | boolean | Set to `true` to include the image loaded from `LocalSourceImage`. (Default is `true`) |
-| includeImage? | boolean | Set to `true` to include the text drawn from `Text`. (Default is `true`) |
-| cropToImageSize? | boolean | Set to `true` to crop output image to the image loaded from `LocalSourceImage`. (Default is `false`) |
+| Property         | Type    | Description                                                                                                                                                                                                                                       |
+| :--------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| folder?          | string  | Android: the folder name in `Pictures` directory<br/>iOS: if `filename` is not null, image will save to temporary directory with folder and filename, otherwise, it will save to camera roll<br/>Windows: the folder name in the Pictures Library |
+| filename?        | string  | the file name of image<br/>iOS: Set to `null` to save image to camera roll.                                                                                                                                                                       |
+| transparent      | boolean | save canvas with transparent background, ignored if imageType is `jpg`                                                                                                                                                                            |
+| imageType        | string  | image file format<br/>Options: `png`, `jpg`                                                                                                                                                                                                       |
+| includeImage?    | boolean | Set to `true` to include the image loaded from `LocalSourceImage`. (Default is `true`)                                                                                                                                                            |
+| includeImage?    | boolean | Set to `true` to include the text drawn from `Text`. (Default is `true`)                                                                                                                                                                          |
+| cropToImageSize? | boolean | Set to `true` to crop output image to the image loaded from `LocalSourceImage`. (Default is `false`)                                                                                                                                              |
 
 ### Path object
 ```javascript
@@ -362,11 +359,11 @@ Note: Because native module cannot read the file in JS bundle, file path cannot 
   mode: 'AspectFill'
 }
 ```
-| Property | Type | Description | Default |
-| :------------ |:---------------|:---------------|:---------------|
-| filename | string | the fold name of the background image file (can be a full path) |  |
-| directory? | string | the directory of the background image file (usually used with [constants](#constants)) | '' |
-| mode? | boolean | Specify how the background image resizes itself to fit or fill the canvas.<br/>Options: `AspectFill`, `AspectFit`, `ScaleToFill` | `AspectFit` |
+| Property   | Type    | Description                                                                                                                      | Default     |
+| :--------- | :------ | :------------------------------------------------------------------------------------------------------------------------------- | :---------- |
+| filename   | string  | the fold name of the background image file (can be a full path)                                                                  |             |
+| directory? | string  | the directory of the background image file (usually used with [constants](#constants))                                           | ''          |
+| mode?      | boolean | Specify how the background image resizes itself to fit or fill the canvas.<br/>Options: `AspectFill`, `AspectFit`, `ScaleToFill` | `AspectFit` |
 
 ### CanvasText object
 ```javascript
@@ -383,18 +380,18 @@ Note: Because native module cannot read the file in JS bundle, file path cannot 
   lineHeightMultiple: 1.2
 }
 ```
-| Property | Type | Description | Default |
-| :------------ |:---------------|:---------------|:---------------| 
-| text | string | the text to display (can be multiline by `\n`) | |
-| font? | string | Android: You can set `font` to `fonts/[filename].ttf` to load font in `android/app/src/main/assets/fonts/` in your Android project<br/>iOS: Set `font` that included with iOS<br/>Windows: Set `font` as explained in the [`Win2D` documentation](https://microsoft.github.io/Win2D/html/P_Microsoft_Graphics_Canvas_Text_CanvasTextFormat_FontFamily.htm) | |
-| fontSize? | number | font size | 12 |
-| fontColor? | string | text color | black |
-| overlay? | string | Set to `TextOnSketch` to overlay drawing with text, otherwise the text will be overlaid with drawing.<br/>Options: `TextOnSketch`, `SketchOnText` | SketchOnText |
-| anchor? | object | Set the origin point of the image. (0, 0) to (1, 1). (0, 0) and (1, 1) indicate the top-left and bottom-right point of the image respectively. | { x: 0, y: 0 } |
-| position | object | Set the position of the image on canvas. If `coordinate` is `Ratio`, (0, 0) and (1, 1) indicate the top-left and bottom-right point of the canvas respectively. | { x: 0, y: 0 } |
-| coordinate? | string | Set to `Absolute` and `Ratio` to treat `position` as absolute position (in point) and proportion respectively.<br/>Options: `Absolute`, `Ratio` | Absolute |
-| alignment? | string | Specify how the text aligns inside container. Only work when `text` is multiline text. | Left |
-| lineHeightMultiple? | number | Multiply line height by this factor. Only work when `text` is multiline text. | 1.0 |
+| Property            | Type   | Description                                                                                                                                                                                                                                                                                                                                                | Default        |
+| :------------------ | :----- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------- |
+| text                | string | the text to display (can be multiline by `\n`)                                                                                                                                                                                                                                                                                                             |                |
+| font?               | string | Android: You can set `font` to `fonts/[filename].ttf` to load font in `android/app/src/main/assets/fonts/` in your Android project<br/>iOS: Set `font` that included with iOS<br/>Windows: Set `font` as explained in the [`Win2D` documentation](https://microsoft.github.io/Win2D/html/P_Microsoft_Graphics_Canvas_Text_CanvasTextFormat_FontFamily.htm) |                |
+| fontSize?           | number | font size                                                                                                                                                                                                                                                                                                                                                  | 12             |
+| fontColor?          | string | text color                                                                                                                                                                                                                                                                                                                                                 | black          |
+| overlay?            | string | Set to `TextOnSketch` to overlay drawing with text, otherwise the text will be overlaid with drawing.<br/>Options: `TextOnSketch`, `SketchOnText`                                                                                                                                                                                                          | SketchOnText   |
+| anchor?             | object | Set the origin point of the image. (0, 0) to (1, 1). (0, 0) and (1, 1) indicate the top-left and bottom-right point of the image respectively.                                                                                                                                                                                                             | { x: 0, y: 0 } |
+| position            | object | Set the position of the image on canvas. If `coordinate` is `Ratio`, (0, 0) and (1, 1) indicate the top-left and bottom-right point of the canvas respectively.                                                                                                                                                                                            | { x: 0, y: 0 } |
+| coordinate?         | string | Set to `Absolute` and `Ratio` to treat `position` as absolute position (in point) and proportion respectively.<br/>Options: `Absolute`, `Ratio`                                                                                                                                                                                                            | Absolute       |
+| alignment?          | string | Specify how the text aligns inside container. Only work when `text` is multiline text.                                                                                                                                                                                                                                                                     | Left           |
+| lineHeightMultiple? | number | Multiply line height by this factor. Only work when `text` is multiline text.                                                                                                                                                                                                                                                                              | 1.0            |
 
 ## Performance
 -------------

--- a/windows/README.md
+++ b/windows/README.md
@@ -17,10 +17,7 @@ RNSketchCanvas supports autolinking. Just call: `npm i @terrylinla/react-native-
 8. In `App.cpp` add `PackageProviders().Append(winrt::RNSketchCanvas::ReactPackageProvider());` before `InitializeComponent();`
 
 ### Using save on Windows
-On Windows, `save()` will save the resulting image in the Pictures library. In order for the application to save successfully, the `Pictures Library` capability must be added to the application's manifest:
-1. Open your solution in Visual Studio 2019 (eg. `windows\yourapp.sln`)
-2. In the main application project, open the `Package.appxmanifest` file.
-3. In the `Capabilities` tab, check the `Pictures Library` capability.
+On Windows, `save()` will save the resulting image in the TemporaryDirectory folder of the application.
 
 ## Module development
 

--- a/windows/RNSketchCanvas/RNSketchCanvas.cpp
+++ b/windows/RNSketchCanvas/RNSketchCanvas.cpp
@@ -355,12 +355,12 @@ namespace winrt::RNSketchCanvas::implementation
   IAsyncOperation<winrt::hstring> RNSketchCanvasView::saveHelper(std::string format, std::string folder, std::string filename, bool transparent, bool includeImage, bool includeText, bool cropToImageSize)
   {
     // Saving in Pictures requires the application having the picturesLibrary capability.
-    StorageFolder picsRoot = KnownFolders::PicturesLibrary();
-    StorageFolder targetSaveFolder = picsRoot;
+    StorageFolder tempRoot = Windows::Storage::ApplicationData::Current().TemporaryFolder();;
+    StorageFolder targetSaveFolder = tempRoot;
     bool try_to_create_folders = false;
     try
     {
-      targetSaveFolder = co_await picsRoot.GetFolderAsync(winrt::to_hstring(folder));
+      targetSaveFolder = co_await tempRoot.GetFolderAsync(winrt::to_hstring(folder));
     } catch (...)
     {
       // Try to create folders.
@@ -368,7 +368,7 @@ namespace winrt::RNSketchCanvas::implementation
     }
     if (try_to_create_folders)
     {
-      targetSaveFolder = co_await picsRoot.CreateFolderAsync(winrt::to_hstring(folder));
+      targetSaveFolder = co_await tempRoot.CreateFolderAsync(winrt::to_hstring(folder));
     }
     StorageFile file = co_await targetSaveFolder.CreateFileAsync(winrt::to_hstring(filename + (format=="png"?".png":".jpg" )), CreationCollisionOption::ReplaceExisting);
 

--- a/windows/RNSketchCanvas/RNSketchCanvas.cpp
+++ b/windows/RNSketchCanvas/RNSketchCanvas.cpp
@@ -354,7 +354,6 @@ namespace winrt::RNSketchCanvas::implementation
 
   IAsyncOperation<winrt::hstring> RNSketchCanvasView::saveHelper(std::string format, std::string folder, std::string filename, bool transparent, bool includeImage, bool includeText, bool cropToImageSize)
   {
-    // Saving in Pictures requires the application having the picturesLibrary capability.
     StorageFolder tempRoot = Windows::Storage::ApplicationData::Current().TemporaryFolder();;
     StorageFolder targetSaveFolder = tempRoot;
     bool try_to_create_folders = false;


### PR DESCRIPTION
We had multiple clients that were unable to save to the PicturesLibrary in Windows even though permission was granted.

That could usually be solved by reinstalling windows, on a fresh install it always worked but that is not a feasible solution for our clients.

Instead I created a PR here which changes the directory to save to from the PicturesLibrary to the TemporaryDirectory of the application.

iOS also uses the TemporaryDirectory to save to while in Android it uses the ExternalStoragePicturesDirectory.