### PR TITLE
Reimplement text via js

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { StyleProp, ViewStyle, ViewProps } from "react-native";
 
+export { TextOverlay } from "./src/TextOverlay";
+
 type ImageType = "png" | "jpg";
 
 type Size = {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ import SketchCanvas from "./src/SketchCanvas";
 import { requestPermissions } from "./src/handlePermissions";
 import { ViewPropTypes } from "deprecated-react-native-prop-types";
 
+export { TextOverlay } from "./src/TextOverlay";
+
 export default class RNSketchCanvas extends React.Component {
     static propTypes = {
         containerStyle: ViewPropTypes.style,

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -9,9 +9,11 @@ import ReactNative, {
     PanResponder,
     PixelRatio,
     Platform,
-    processColor
+    processColor,
+    View
 } from "react-native";
 import { requestPermissions } from "./handlePermissions";
+import { TextOverlay } from "./TextOverlay";
 import { ViewPropTypes } from "deprecated-react-native-prop-types";
 
 const RNSketchCanvas = requireNativeComponent("RNSketchCanvas", SketchCanvas, {
@@ -239,30 +241,33 @@ class SketchCanvas extends React.Component {
 
     render() {
         return (
-            <RNSketchCanvas
-                ref={(ref) => {
-                    this._handle = ReactNative.findNodeHandle(ref);
-                }}
-                style={this.props.style}
-                onLayout={(e) => {
-                    this._size = { width: e.nativeEvent.layout.width, height: e.nativeEvent.layout.height };
-                    this._initialized = true;
-                    this._pathsToProcess.length > 0 && this._pathsToProcess.forEach((p) => this.addPath(p));
-                }}
-                {...this.panResponder.panHandlers}
-                onChange={(e) => {
-                    if (e.nativeEvent.hasOwnProperty("pathsUpdate")) {
-                        this.props.onPathsChange(e.nativeEvent.pathsUpdate);
-                    } else if (e.nativeEvent.hasOwnProperty("success") && e.nativeEvent.hasOwnProperty("path")) {
-                        this.props.onSketchSaved(e.nativeEvent.success, e.nativeEvent.path);
-                    } else if (e.nativeEvent.hasOwnProperty("success")) {
-                        this.props.onSketchSaved(e.nativeEvent.success);
-                    }
-                }}
-                localSourceImage={this.props.localSourceImage}
-                permissionDialogTitle={this.props.permissionDialogTitle}
-                permissionDialogMessage={this.props.permissionDialogMessage}
-            />
+            <View style={this.props.style}>
+                <RNSketchCanvas
+                    ref={(ref) => {
+                        this._handle = ReactNative.findNodeHandle(ref);
+                    }}
+                    style={this.props.style}
+                    onLayout={(e) => {
+                        this._size = { width: e.nativeEvent.layout.width, height: e.nativeEvent.layout.height };
+                        this._initialized = true;
+                        this._pathsToProcess.length > 0 && this._pathsToProcess.forEach((p) => this.addPath(p));
+                    }}
+                    {...this.panResponder.panHandlers}
+                    onChange={(e) => {
+                        if (e.nativeEvent.hasOwnProperty("pathsUpdate")) {
+                            this.props.onPathsChange(e.nativeEvent.pathsUpdate);
+                        } else if (e.nativeEvent.hasOwnProperty("success") && e.nativeEvent.hasOwnProperty("path")) {
+                            this.props.onSketchSaved(e.nativeEvent.success, e.nativeEvent.path);
+                        } else if (e.nativeEvent.hasOwnProperty("success")) {
+                            this.props.onSketchSaved(e.nativeEvent.success);
+                        }
+                    }}
+                    localSourceImage={this.props.localSourceImage}
+                    permissionDialogTitle={this.props.permissionDialogTitle}
+                    permissionDialogMessage={this.props.permissionDialogMessage}
+                />
+                <TextOverlay text={this.props.text} />
+            </View>
         );
     }
 }

--- a/src/TextOverlay.tsx
+++ b/src/TextOverlay.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { StyleSheet, StyleProp, Text, TextStyle, View } from "react-native";
+
+type CanvasText = {
+    position: { x: number; y: number };
+    style?: StyleProp<TextStyle>;
+    text: string;
+};
+
+type TextOverlayProps = { text?: CanvasText[] };
+
+export function TextOverlay(props: TextOverlayProps) {
+    return (
+        <View pointerEvents="none" style={Styles.container}>
+            {props.text?.map((item, index) => (
+                <Text
+                    key={index}
+                    style={[item.style, {
+                        left: item.position.x,
+                        top: item.position.y,
+                        position: "absolute"
+                    }]}>
+                    {item.text}
+                </Text>
+            ))}
+        </View>
+    );
+}
+
+const Styles = StyleSheet.create({
+    container: { width: "100%", height: "100%", position: "absolute" }
+});


### PR DESCRIPTION
Implement text on canvas in js.

I was unable to get the example project to compile (tried both Android and iOS), so not sure if it is properly integrated.  So, I also did not add this to the example project.  However, I did test in my own app by patching node_modules.

I did not add typescript to the toolchain for this library, since I presume you will want to do so during #13 .

Usage:
```tsx
import React from 'react';
import { SketchCanvas } from '@wwimmo/react-native-sketch-canvas';

export default function App() {
  return (
    <SketchCanvas
      style={{ flex: 1 }}
      text={[
        {
          position: { x: 50, y: 200 },
          style: { color: 'blue', fontSize: 20 },
          text: 'Example text.',
        },
      ]}
    />
  );
}
```

See #16