### PR TITLE
Fix rotation on Android, using EXIF data

### DIFF
--- a/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
+++ b/android/src/main/java/com/terrylinla/rnsketchcanvas/SketchCanvas.java
@@ -9,6 +9,8 @@ import android.graphics.Paint;
 import android.graphics.PointF;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
 import android.os.Environment;
 import android.util.Base64;
 import android.util.Log;
@@ -25,6 +27,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+
+class CanvasText {
+    public String text;
+    public Paint paint;
+    public PointF anchor, position, drawPosition, lineOffset;
+    public boolean isAbsoluteCoordinate;
+    public Rect textBounds;
+    public float height;
+}
 
 public class SketchCanvas extends View {
 
@@ -44,6 +55,10 @@ public class SketchCanvas extends View {
     private Bitmap mBackgroundImage;
     private String mContentMode;
 
+    private ArrayList<CanvasText> mArrCanvasText = new ArrayList<CanvasText>();
+    private ArrayList<CanvasText> mArrTextOnSketch = new ArrayList<CanvasText>();
+    private ArrayList<CanvasText> mArrSketchOnText = new ArrayList<CanvasText>();
+
     public SketchCanvas(ThemedReactContext context) {
         super(context);
         mContext = context;
@@ -56,10 +71,30 @@ public class SketchCanvas extends View {
                 "drawable", 
                 mContext.getPackageName());
             BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
+            File file = new File(filename, directory == null ? "" : directory);
             Bitmap bitmap = res == 0 ? 
-                BitmapFactory.decodeFile(new File(filename, directory == null ? "" : directory).toString(), bitmapOptions) :
+                BitmapFactory.decodeFile(file.toString(), bitmapOptions) :
                 BitmapFactory.decodeResource(mContext.getResources(), res);
-            if(bitmap != null) {
+
+            try {
+                ExifInterface exif = new ExifInterface(file.getAbsolutePath());
+                Matrix matrix = new Matrix();
+
+                int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
+                if (orientation == ExifInterface.ORIENTATION_ROTATE_90) {
+                    matrix.postRotate(90);
+                } else if (orientation == ExifInterface.ORIENTATION_ROTATE_180) {
+                    matrix.postRotate(180);
+                } else if (orientation == ExifInterface.ORIENTATION_ROTATE_270) {
+                    matrix.postRotate(270);
+                }
+
+                bitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true); // rotating bitmap
+            } catch (Exception e) {
+
+            }
+
+            if (bitmap != null) {
                 mBackgroundImage = bitmap;
                 mOriginalHeight = bitmap.getHeight();
                 mOriginalWidth = bitmap.getWidth();
@@ -71,6 +106,96 @@ public class SketchCanvas extends View {
             }
         }
         return false;
+    }
+
+    public void setCanvasText(ReadableArray aText) {
+        mArrCanvasText.clear();
+        mArrSketchOnText.clear();
+        mArrTextOnSketch.clear();
+
+        if (aText != null) {
+            for (int i=0; i<aText.size(); i++) {
+                ReadableMap property = aText.getMap(i);
+                if (property.hasKey("text")) {
+                    String alignment = property.hasKey("alignment") ? property.getString("alignment") : "Left";
+                    int lineOffset = 0, maxTextWidth = 0;
+                    String[] lines = property.getString("text").split("\n");
+                    ArrayList<CanvasText> textSet = new ArrayList<CanvasText>(lines.length);
+                    for (String line: lines) {
+                        ArrayList<CanvasText> arr = property.hasKey("overlay") && "TextOnSketch".equals(property.getString("overlay")) ? mArrTextOnSketch : mArrSketchOnText;
+                        CanvasText text = new CanvasText();
+                        Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+                        p.setTextAlign(Paint.Align.LEFT);
+                        text.text = line;
+                        if (property.hasKey("font")) {
+                            Typeface font;
+                            try {
+                                font = Typeface.createFromAsset(mContext.getAssets(), property.getString("font"));
+                            } catch(Exception ex) {
+                                font = Typeface.create(property.getString("font"), Typeface.NORMAL);
+                            }
+                            p.setTypeface(font);
+                        }
+                        p.setTextSize(property.hasKey("fontSize") ? (float)property.getDouble("fontSize") : 12);
+                        p.setColor(property.hasKey("fontColor") ? property.getInt("fontColor") : 0xFF000000);
+                        text.anchor = property.hasKey("anchor") ? new PointF((float)property.getMap("anchor").getDouble("x"), (float)property.getMap("anchor").getDouble("y")) : new PointF(0, 0);
+                        text.position = property.hasKey("position") ? new PointF((float)property.getMap("position").getDouble("x"), (float)property.getMap("position").getDouble("y")) : new PointF(0, 0);
+                        text.paint = p;
+                        text.isAbsoluteCoordinate = !(property.hasKey("coordinate") && "Ratio".equals(property.getString("coordinate")));
+                        text.textBounds = new Rect();
+                        p.getTextBounds(text.text, 0, text.text.length(), text.textBounds);
+
+                        text.lineOffset = new PointF(0, lineOffset);
+                        lineOffset += text.textBounds.height() * 1.5 * (property.hasKey("lineHeightMultiple") ? property.getDouble("lineHeightMultiple") : 1);
+                        maxTextWidth = Math.max(maxTextWidth, text.textBounds.width());
+
+                        arr.add(text);
+                        mArrCanvasText.add(text);
+                        textSet.add(text);
+                    }
+                    for(CanvasText text: textSet) {
+                        text.height = lineOffset;
+                        if (text.textBounds.width() < maxTextWidth) {
+                            float diff = maxTextWidth - text.textBounds.width();
+                            text.textBounds.left += diff * text.anchor.x;
+                            text.textBounds.right += diff * text.anchor.x;
+                        }
+                    }
+                    if (getWidth() > 0 && getHeight() > 0) {
+                        for(CanvasText text: textSet) {
+                            text.height = lineOffset;
+                            PointF position = new PointF(text.position.x, text.position.y);
+                            if (!text.isAbsoluteCoordinate) {
+                                position.x *= getWidth();
+                                position.y *= getHeight();
+                            }
+                            position.x -= text.textBounds.left;
+                            position.y -= text.textBounds.top;
+                            position.x -= (text.textBounds.width() * text.anchor.x);
+                            position.y -= (text.height * text.anchor.y);
+                            text.drawPosition = position;
+                        }
+                    }
+                    if (lines.length > 1) {
+                        for(CanvasText text: textSet) {
+                            switch(alignment) {
+                                case "Left":
+                                default:
+                                    break;
+                                case "Right":
+                                    text.lineOffset.x = (maxTextWidth - text.textBounds.width());
+                                    break;
+                                case "Center":
+                                    text.lineOffset.x = (maxTextWidth - text.textBounds.width()) / 2;
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        invalidateCanvas(false);
     }
 
     public void clear() {
@@ -161,11 +286,11 @@ public class SketchCanvas extends View {
             event);
     }
 
-    public void save(String format, String folder, String filename, boolean transparent, boolean includeImage, boolean cropToImageSize) {
+    public void save(String format, String folder, String filename, boolean transparent, boolean includeImage, boolean includeText, boolean cropToImageSize) {
         File f = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES) + File.separator + folder);
         boolean success = f.exists() ? true : f.mkdirs();
         if (success) {
-            Bitmap bitmap = createImage(format.equals("png") && transparent, includeImage, cropToImageSize);
+            Bitmap bitmap = createImage(format.equals("png") && transparent, includeImage, includeText, cropToImageSize);
 
             File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES) +
                 File.separator + folder + File.separator + filename + (format.equals("png") ? ".png" : ".jpg"));
@@ -185,9 +310,9 @@ public class SketchCanvas extends View {
         }
     }
 
-    public String getBase64(String format, boolean transparent, boolean includeImage, boolean cropToImageSize) {
+    public String getBase64(String format, boolean transparent, boolean includeImage, boolean includeText, boolean cropToImageSize) {
         WritableMap event = Arguments.createMap();
-        Bitmap bitmap = createImage(format.equals("png") && transparent, includeImage, cropToImageSize);
+        Bitmap bitmap = createImage(format.equals("png") && transparent, includeImage, includeText, cropToImageSize);
         ByteArrayOutputStream byteArrayOS = new ByteArrayOutputStream();
 
         bitmap.compress(
@@ -209,6 +334,21 @@ public class SketchCanvas extends View {
                     Bitmap.Config.ARGB_8888);
             mTranslucentDrawingCanvas = new Canvas(mTranslucentDrawingBitmap);
             
+            for(CanvasText text: mArrCanvasText) {
+                PointF position = new PointF(text.position.x, text.position.y);
+                if (!text.isAbsoluteCoordinate) {
+                    position.x *= getWidth();
+                    position.y *= getHeight();
+                }
+
+                position.x -= text.textBounds.left;
+                position.y -= text.textBounds.top;
+                position.x -= (text.textBounds.width() * text.anchor.x);
+                position.y -= (text.height * text.anchor.y);
+                text.drawPosition = position;
+
+            }
+
             mNeedsFullRedraw = true;
             invalidate();
         }
@@ -234,12 +374,20 @@ public class SketchCanvas extends View {
                 null);
         }
 
+        for(CanvasText text: mArrSketchOnText) {
+            canvas.drawText(text.text, text.drawPosition.x + text.lineOffset.x, text.drawPosition.y + text.lineOffset.y, text.paint);
+        }
+
         if (mDrawingBitmap != null) {
             canvas.drawBitmap(mDrawingBitmap, 0, 0, mPaint);
         }
 
         if (mTranslucentDrawingBitmap != null && mCurrentPath != null && mCurrentPath.isTranslucent) {
             canvas.drawBitmap(mTranslucentDrawingBitmap, 0, 0, mPaint);
+        }
+
+        for(CanvasText text: mArrTextOnSketch) {
+            canvas.drawText(text.text, text.drawPosition.x + text.lineOffset.x, text.drawPosition.y + text.lineOffset.y, text.paint);
         }
     }
 
@@ -255,7 +403,7 @@ public class SketchCanvas extends View {
         invalidate();
     }
 
-    private Bitmap createImage(boolean transparent, boolean includeImage, boolean cropToImageSize) {
+    private Bitmap createImage(boolean transparent, boolean includeImage, boolean includeText, boolean cropToImageSize) {
         Bitmap bitmap = Bitmap.createBitmap(
             mBackgroundImage != null && cropToImageSize ? mOriginalWidth : getWidth(),
             mBackgroundImage != null && cropToImageSize ? mOriginalHeight : getHeight(), 
@@ -270,6 +418,12 @@ public class SketchCanvas extends View {
             canvas.drawBitmap(mBackgroundImage, null, targetRect, null);
         }
 
+        if (includeText) {
+            for(CanvasText text: mArrSketchOnText) {
+                canvas.drawText(text.text, text.drawPosition.x + text.lineOffset.x, text.drawPosition.y + text.lineOffset.y, text.paint);
+            }
+        }
+
         if (mBackgroundImage != null && cropToImageSize) {
             Rect targetRect = new Rect();
             Utility.fillImage(mDrawingBitmap.getWidth(), mDrawingBitmap.getHeight(), 
@@ -279,6 +433,11 @@ public class SketchCanvas extends View {
             canvas.drawBitmap(mDrawingBitmap, 0, 0, mPaint);
         }
 
+        if (includeText) {
+            for(CanvasText text: mArrTextOnSketch) {
+                canvas.drawText(text.text, text.drawPosition.x + text.lineOffset.x, text.drawPosition.y + text.lineOffset.y, text.paint);
+            }
+        }
         return bitmap;
     }
 }


### PR DESCRIPTION
Some Android phones have their camera sensors mounted sideways, upside down, ect. The BitmapFactory#decodeFile method does not take this into account, by default. So, when the file is decoded, it could end up getting shown in an incorrect orientation on the canvas.

iOS manages this correctly already. This PR just fixes the issue for Android devices.

courtesy: https://github.com/terrylinla/react-native-sketch-canvas/pull/135

cc: @andibraunhangartner @creambyemute